### PR TITLE
refactor: unify agnostic tagging and language config support

### DIFF
--- a/python/dolma/cli/tagger.py
+++ b/python/dolma/cli/tagger.py
@@ -13,8 +13,9 @@ from dolma.core.paths import glob_path
 from dolma.core.registry import TaggerRegistry
 from dolma.core.runtime import create_and_run_tagger
 from dolma.core.utils import import_modules
+from dolma.utils.language_config import get_supported_languages
 
-SUPPORTED_LANGUAGES = ["agnostic", "en", "spa", "ara", "zho", "fra"]
+SUPPORTED_LANGUAGES = get_supported_languages()
 
 @dataclass
 class ProfilerConfig:

--- a/python/dolma/data/language_config.json
+++ b/python/dolma/data/language_config.json
@@ -27,6 +27,6 @@
       "iso639_1": "zh",
       "min_words_per_line": 3,
       "eol_punctuation": [".", "?", "!", "\"", "。", ",.", "？", "！", "\""],
-      "required_words" : ["/TODO"]
+      "required_words" : ["的", "了", "是", "在", "有", "这"]
     }
   }

--- a/python/dolma/data/language_config.json
+++ b/python/dolma/data/language_config.json
@@ -3,30 +3,35 @@
       "iso639_1": "en",
       "min_words_per_line": 3,
       "eol_punctuation": [".", "?", "!", "\""],
-      "required_words" : ["the", "be", "to", "of", "and", "that", "have", "with"]
+      "required_words" : ["the", "be", "to", "of", "and", "that", "have", "with"],
+      "alphanum_regex": "[a-zA-Z0-9]"
     },
     "spa": {
       "iso639_1": "es",
       "min_words_per_line": 3,
       "eol_punctuation": [".", "?", "!", "\""],
-      "required_words" : ["el", "la", "es", "a", "de", "del", "y", "que", "un", "una", "uno"]
+      "required_words" : ["el", "la", "es", "a", "de", "del", "y", "que", "un", "una", "uno"],
+      "alphanum_regex": "\\p{Latin}|\\d"
     },
     "fra": {
       "iso639_1": "fr",
       "min_words_per_line": 3,
       "eol_punctuation": [".", "?", "!", "\"", "»"],
-      "required_words" : ["le", "la", "les", "est", "à", "de", "du", "des", "et", "que", "qui", "a", "avec", "un", "une"]
+      "required_words" : ["le", "la", "les", "est", "à", "de", "du", "des", "et", "que", "qui", "a", "avec", "un", "une"],
+      "alphanum_regex": "\\p{Latin}|\\d"
     },
     "ara": {
       "iso639_1": "ar",
       "min_words_per_line": 3,
       "eol_punctuation": [".", "؟", "!", "“", "”", "\""],
-      "required_words" : ["أن", "لا", "أو", "إلى", "ولا", "من", "مع", "لن", "يا", "لم"]
+      "required_words" : ["أن", "لا", "أو", "إلى", "ولا", "من", "مع", "لن", "يا", "لم"],
+      "alphanum_regex": "\\p{Arabic}|\\d"
     },
     "zho": {
       "iso639_1": "zh",
       "min_words_per_line": 3,
       "eol_punctuation": [".", "?", "!", "\"", "。", ",.", "？", "！", "\""],
-      "required_words" : ["的", "了", "是", "在", "有", "这"]
+      "required_words" : ["的", "了", "是", "在", "有", "这"],
+      "alphanum_regex": "\\p{Han}|\\d"
     }
   }

--- a/python/dolma/taggers/__init__.py
+++ b/python/dolma/taggers/__init__.py
@@ -22,7 +22,8 @@ from .agnostic import (
 
 from .code import (
     code_taggers,
-    starcoder,
 )
 
-# TODO repetitions
+from .repetitions import (
+    repetitions_taggers,
+)

--- a/python/dolma/taggers/agnostic/punctuation.py
+++ b/python/dolma/taggers/agnostic/punctuation.py
@@ -5,52 +5,16 @@ from dolma.core.data_types import DocResult, Document, Span
 from dolma.core.registry import TaggerRegistry
 from dolma.core.taggers import BaseTagger
 from dolma.core.utils import split_paragraphs
+from dolma.utils.language_config import get_language_config
 
 logger = logging.getLogger(__name__)
 
-@TaggerRegistry.add("not_alphanum_paragraph_monolingual")
+@TaggerRegistry.add("not_alphanum_paragraph_agnostic")
 class NotAlphanumParagraphMonolingual(BaseTagger):
     def __init__(self, language: str = "en") -> None:
-        if language == "en":
-            self.re_has_alphanum = regex.compile(r"[a-zA-Z0-9]", regex.UNICODE)
-        elif language == "spa":
-            self.re_has_alphanum = regex.compile(r"\p{Latin}|\d", regex.UNICODE)
-        else:
-            logger.warning(f"Unsupported language '%s'. Defaulting to multilingual mode.", language)
-            self.re_has_alphanum = regex.compile(r"\p{L}|\p{N}", regex.UNICODE)
+        config = get_language_config(language)
+        self.re_has_alphanum = regex.compile(config["alphanum_regex"], regex.UNICODE)
         
-        self.re_all_punctuation = regex.compile(
-            r"^("
-            r"\p{P}|"
-            r"\s|"
-            r"["
-            "\U0001f300-\U0001f64f"
-            "\U0001f680-\U0001f6ff"
-            "\u2600-\u26ff\u2700-\u27bf"
-            r"]+"
-            r")+$",
-            regex.UNICODE,
-        )
-
-    def predict(self, doc: Document) -> DocResult:
-        spans = []
-
-        for para in split_paragraphs(text=doc.text):
-            if self.re_has_alphanum.search(para.text):
-                continue
-
-            if self.re_all_punctuation.search(para.text):
-                spans.append(Span(start=para.start, end=para.end, type="all_punct", score=1))
-
-        if not spans:
-            spans.append(Span(start=0, end=len(doc.text), type="all_punct", score=0))
-
-        return DocResult(doc=doc, spans=spans)
-
-@TaggerRegistry.add("not_alphanum_paragraph_multilingual")
-class NotAlphanumParagraphMultilingual(BaseTagger):
-    def __init__(self) -> None:
-        self.re_has_alphanum = regex.compile(r"\p{L}|\p{N}", regex.UNICODE)
         self.re_all_punctuation = regex.compile(
             r"^("
             r"\p{P}|"

--- a/python/dolma/utils/language_config.py
+++ b/python/dolma/utils/language_config.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_MIN_WORDS_PER_LINE = 3
 DEFAULT_EOL_PUNCTUATION = {".", "?", "!", '"'}
 DEFAULT_ISO639_1 = "en"
+DEFAULT_ALPHANUM_REGEX = r"\p{L}|\p{N}"
 
 # languages that don't use spaces to delimit words
 SPACELESS_LANGUAGES = {"zho"}
@@ -17,9 +18,10 @@ SPACELESS_LANGUAGES = {"zho"}
 def get_language_config(language: str) -> Dict:
     """
     Loads language-specific configuration from a JSON file, including:
-        - min_words_per_line
-        - eol_punctuation
-        - iso639_1 (FastText-compatible 2-letter code)
+        - min_words_per_line: Minimum number of words per line to consider valid
+        - eol_punctuation: Set of punctuation characters considered valid at end of sentence
+        - iso639_1: FastText-compatible 2-letter code
+        - alphanum_regex: Unicode-aware regex pattern for checking presence of alphanumeric characters
 
     Falls back to English or hardcoded defaults if language is missing.
     """
@@ -38,6 +40,7 @@ def get_language_config(language: str) -> Dict:
         "min_words_per_line": lang_config.get("min_words_per_line", DEFAULT_MIN_WORDS_PER_LINE),
         "eol_punctuation": set(lang_config.get("eol_punctuation", DEFAULT_EOL_PUNCTUATION)),
         "iso639_1": lang_config.get("iso639_1", DEFAULT_ISO639_1),
+        "alphanum_regex": lang_config.get("alphanum_regex", DEFAULT_ALPHANUM_REGEX),
     }
 
 

--- a/python/dolma/utils/language_config.py
+++ b/python/dolma/utils/language_config.py
@@ -44,6 +44,24 @@ def get_language_config(language: str) -> Dict:
     }
 
 
+def get_supported_languages() -> Set[str]:
+    """
+    Returns the set of supported languages, based on the keys in the language config file.
+    """
+    config_file = Path(__file__).parent / "../data/language_config.json"
+
+    try:
+        with config_file.open("r", encoding="utf-8") as f:
+            config_data = json.load(f)
+    except Exception:
+        logger.exception("Failed to load language config file.")
+        config_data = {}
+
+    supported = set(config_data.keys())
+    supported.add("agnostic")
+    return supported
+
+
 def get_spaceless_languages() -> Set[str]:
     """
     Returns the set of languages that do not use spaces to separate words (e.g. Chinese).


### PR DESCRIPTION
### implementation
- add chinese “required” words to lang config
- agnostic gopher tagger - add `symbol_to_token_ratio` and `required_token_count` back, works with “required_words” var from lang config
- agnostic punctuation tagger - consolidate monolingual and multilingual punctuation taggers into one called `not_alphanum_paragraph_agnostic`, which uses regex var from lang config
- add function in utils to dynamically load supported languages from lang config keys
- update init file with all current taggers